### PR TITLE
temporary patch to fix the blank streams page

### DIFF
--- a/strims_content.php
+++ b/strims_content.php
@@ -55,8 +55,8 @@
     });
     strim_list.sort(function(a,b) {
       // give LIVE streams more weight in sorting higher
-      var amulti = api_data.metadata[api_data.metaindex[a.strim]]['live'] ? 10 : 1;
-      var bmulti = api_data.metadata[api_data.metaindex[b.strim]]['live'] ? 10 : 1;
+      var amulti = api_data.metadata.hasOwnProperty(api_data.metaindex[a.strim]]) && api_data.metadata[api_data.metaindex[a.strim]]['live'] ? 10 : 1;
+      var bmulti = api_data.metadata.hasOwnProperty(api_data.metaindex[b.strim]]) && api_data.metadata[api_data.metaindex[b.strim]]['live'] ? 10 : 1;
       if (amulti*a.viewercount < bmulti*b.viewercount)
          return 1;
       if (amulti*a.viewercount > bmulti*b.viewercount)


### PR DESCRIPTION
i think this stems from the async nature of the metadata, when it's checked against live streams lists, it can get inconsistent for some reason. this should be a short term fix.